### PR TITLE
Handbrake: Add version 1.5.1

### DIFF
--- a/bucket/handbrake.json
+++ b/bucket/handbrake.json
@@ -1,0 +1,66 @@
+{
+    "##": "Handbrake with .NET runtime included",
+    "version": "1.5.1",
+    "description": "A tool for converting video from nearly any format to a selection of modern, widely supported codecs.",
+    "homepage": "https://handbrake.fr",
+    "license": "GPL-2.0-only",
+    "architecture": {
+        "64bit": {
+            "url": [
+                "https://github.com/HandBrake/HandBrake/releases/download/1.5.1/HandBrake-1.5.1-x86_64-Win_GUI.zip",
+                "https://dot.net/v1/dotnet-install.ps1"
+            ],
+            "hash": [
+                "69e499d88df6f77a5ce663c8f5ae3ff2e6210a908152a7c437d10bca7294d0be",
+                "2fcb0aa21b7d06e92124fd65abf23e0b43fde22ca8a8bd2b47aa6da90ecccdd7"
+            ]
+        }
+    },
+    "extract_dir": "HandBrake",
+    "pre_install": "",
+    "installer": {
+        "script": [
+
+            "Invoke-Expression \"$dir\\dotnet-install.ps1 -InstallDir '$dir\\runtime\\' -NoPath\" ",
+            "Get-ChildItem $dir\\runtime\\hostfxr.dll -Recurse | Move-Item  -Destination \"$dir\" ",
+            "Move-Item -Path $dir\\runtime\\shared -Destination $dir\\",
+            "Remove-Item \"$dir\\runtime\" -Recurse",
+            "Remove-Item \"$dir\\dotnet-install.ps1\" ",
+            "if (!(Test-Path \"$persist_dir\\portable.ini\")) {",
+            "    if (!(Test-Path \"$persist_dir\\storage\") -And (Test-Path \"$env:APPDATA\\HandBrake\")) {",
+            "        New-Item \"$persist_dir\" -ItemType Directory -ErrorAction SilentlyContinue | Out-Null",
+            "        Move-Item -Path \"$env:APPDATA\\HandBrake\" -Destination \"$persist_dir\\storage\" -Force",
+            "    }",
+            "    Copy-Item \"$dir\\portable.ini.template\" \"$dir\\portable.ini\" -Force",
+            "}"
+        ]
+    },
+    "persist": [
+        "portable.ini",
+        "storage",
+        "tmp"
+    ],
+    "shortcuts": [
+        [
+            "HandBrake.exe",
+            "HandBrake"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/HandBrake/HandBrake"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": [
+                    "https://github.com/HandBrake/HandBrake/releases/download/$version/HandBrake-$version-x86_64-Win_GUI.zip",
+                    "https://dot.net/v1/dotnet-install.ps1"
+                ]
+            }
+        },
+        "hash": {
+            "url": "https://handbrake.fr/rotation.php?file=$basename",
+            "regex": "<td>$sha256</td>"
+        }
+    }
+}


### PR DESCRIPTION
Since the developers of Handbrake are currently reluctant to include the .NET runtime in their installation packages (see https://github.com/HandBrake/HandBrake/issues/4594#issuecomment-1270547768 ), and since the official extras bucket for [Handbrake](https://github.com/ScoopInstaller/Extras/blob/master/bucket/handbrake.json) relies on the [.NET runtime](https://github.com/ScoopInstaller/Extras/blob/master/bucket/windowsdesktop-runtime-lts.json) requiring administrator privileges to install, I have written this manifest file to provide a way to install and use Handbrake without administrator privileges.
The main difference from the official version is that during installation it calls dotnet-install.ps1 (provided by Microsoft) to download and unpack the .NET runtime from the official one, process it and place it in the Handbrake directory.
